### PR TITLE
修复macOS构建错误和工作流配置

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -85,8 +85,29 @@ jobs:
       - name: Create Python executable for tauri (macOS)
         if: matrix.os-target.os == 'macos-latest'
         run: |
+          echo "📱 开始构建macOS可执行文件..."
           pyinstaller entrypoint.onefile.spec
-          cp dist/entrypoint ./tauri/src-tauri/binaries/st_score_analyzer-${{ matrix.os-target.target }}
+          echo "✅ PyInstaller构建完成，检查输出文件："
+          ls -la dist/ || echo "❌ dist目录不存在"
+          
+          if [ -f "dist/entrypoint" ]; then
+            echo "✅ 找到可执行文件 dist/entrypoint"
+            file dist/entrypoint
+            
+            # 确保目标目录存在
+            mkdir -p ./tauri/src-tauri/binaries/
+            
+            # 复制文件
+            cp dist/entrypoint ./tauri/src-tauri/binaries/st_score_analyzer-${{ matrix.os-target.target }}
+            
+            echo "✅ 文件复制成功，验证："
+            ls -la ./tauri/src-tauri/binaries/st_score_analyzer-${{ matrix.os-target.target }}
+          else
+            echo "❌ 未找到可执行文件 dist/entrypoint"
+            echo "可用的文件："
+            find dist/ -type f 2>/dev/null || echo "没有文件生成"
+            exit 1
+          fi
 
       - name: Install tauri dependencies (Ubuntu)
         if: matrix.os-target.os == 'ubuntu-latest'

--- a/.github/workflows/build-windows-exe.yml
+++ b/.github/workflows/build-windows-exe.yml
@@ -6,11 +6,11 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [ "release" ]
+    branches: [ "release", "main", "new" ]
     tags:
     - 'v*'
   pull_request:
-    branches: [ "release" ]
+    branches: [ "release", "main", "new" ]
 
 jobs:
   build-windows:

--- a/entrypoint.onefile.spec
+++ b/entrypoint.onefile.spec
@@ -76,5 +76,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon='build_assets/icon.ico' if (project_root / 'build_assets' / 'icon.ico').exists() else None,
+    icon='build_assets/icon.icns' if (project_root / 'build_assets' / 'icon.icns').exists() else None,
 )


### PR DESCRIPTION
🔧 修复内容:
- 修正entrypoint.onefile.spec使用正确的.icns图标文件（macOS）
- 增强macOS构建步骤的错误处理和调试信息
- 添加文件存在验证和详细日志输出
- 修复build-windows-exe.yml的分支配置

🎯 解决问题:
- macOS PyInstaller构建失败
- 工作流手动运行支持
- 文件复制错误的调试能力